### PR TITLE
New feature automatically detects the latest version / Fix broken links

### DIFF
--- a/aarch64/install.sh
+++ b/aarch64/install.sh
@@ -1,10 +1,21 @@
 #!/bin/bash
 
-URL_DISTR="https://dl-cdn.alpinelinux.org/alpine/v3.18/releases/aarch64/alpine-virt-3.18.3-aarch64.iso"
-URL_EFI="http://ftp.de.debian.org/debian/pool/main/e/edk2/qemu-efi-aarch64_2023.05-2_all.deb"
-
-DISK_NAME="alpine.aarch64.qcow2"
+ALP_ARCH=aarch64
+DISK_NAME="alpine.$ALP_ARCH.qcow2"
 DISK_SIZE="8G"
+
+#Get last release and iso file name
+ALP_VIRT_LAST_ISO=$(wget -qO- "https://dl-cdn.alpinelinux.org/alpine/latest-stable/releases/$ALP_ARCH/latest-releases.yaml" | grep "iso: alpine-virt" | cut -d':' -f2- | tr -d '[:space:]')
+
+ALP_VIRT_VERSION=$(echo $ALP_VIRT_LAST_ISO | cut -d'-' -f3)
+
+#Display detected last-version of virt
+echo "Last Alpine release for $ALP_ARCH version: $ALP_VIRT_VERSION  iso:$ALP_VIRT_LAST_ISO"
+echo "Starting download.."
+
+URL_DISTR="https://dl-cdn.alpinelinux.org/alpine/latest-stable/releases/$ALP_ARCH/$ALP_VIRT_LAST_ISO"
+URL_EFI="http://security.debian.org/debian-security/pool/updates/main/e/edk2/qemu-efi-aarch64_2022.11-6+deb12u1_all.deb"
+
 
 # Download Alpine
 if [ ! -f $(basename $URL_DISTR) ]; then

--- a/aarch64/run.sh
+++ b/aarch64/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-
-DISK_NAME="alpine.aarch64.qcow2"
+ALP_ARCH=aarch64
+DISK_NAME="alpine.$ALP_ARCH.qcow2"
 PORT="2221"
 
 # Run qemu

--- a/armv7/install.sh
+++ b/armv7/install.sh
@@ -1,10 +1,21 @@
 #!/bin/bash
 
-URL_DISTR="https://dl-cdn.alpinelinux.org/alpine/v3.18/releases/armv7/alpine-virt-3.18.3-armv7.iso"
-URL_EFI="http://ftp.de.debian.org/debian/pool/main/e/edk2/qemu-efi-arm_2023.05-2_all.deb"
-
-DISK_NAME="alpine.armv7.qcow2"
+ALP_ARCH=armv7
+DISK_NAME="alpine.$ALP_ARCH.qcow2"
 DISK_SIZE="8G"
+
+#Get last release and iso file name
+ALP_VIRT_LAST_ISO=$(wget -qO- "https://dl-cdn.alpinelinux.org/alpine/latest-stable/releases/$ALP_ARCH/latest-releases.yaml" | grep "iso: alpine-virt" | cut -d':' -f2- | tr -d '[:space:]')
+
+ALP_VIRT_VERSION=$(echo $ALP_VIRT_LAST_ISO | cut -d'-' -f3)
+
+#Display detected last-version of virt
+echo "Last Alpine release for $ALP_ARCH version: $ALP_VIRT_VERSION  iso:$ALP_VIRT_LAST_ISO"
+echo "Starting download.."
+
+URL_DISTR="https://dl-cdn.alpinelinux.org/alpine/latest-stable/releases/$ALP_ARCH/$ALP_VIRT_LAST_ISO"
+URL_EFI="http://security.debian.org/debian-security/pool/updates/main/e/edk2/qemu-efi-arm_2022.11-6+deb12u1_all.deb"
+
 
 # Download Alpine
 if [ ! -f $(basename $URL_DISTR) ]; then

--- a/armv7/run.sh
+++ b/armv7/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-
-DISK_NAME="alpine.armv7.qcow2"
+ALP_ARCH=armv7
+DISK_NAME="alpine.$ALP_ARCH.qcow2"
 PORT="2222"
 
 # Run qemu

--- a/x86/install.sh
+++ b/x86/install.sh
@@ -1,9 +1,19 @@
 #!/bin/bash
 
-URL_DISTR="https://dl-cdn.alpinelinux.org/alpine/v3.18/releases/x86/alpine-virt-3.18.4-x86.iso"
-
-DISK_NAME="alpine.x86.qcow2"
+ALP_ARCH=x86
+DISK_NAME="alpine.$ALP_ARCH.qcow2"
 DISK_SIZE="8G"
+
+#Get last release and iso file name
+ALP_VIRT_LAST_ISO=$(wget -qO- "https://dl-cdn.alpinelinux.org/alpine/latest-stable/releases/$ALP_ARCH/latest-releases.yaml" | grep "iso: alpine-virt" | cut -d':' -f2- | tr -d '[:space:]')
+
+ALP_VIRT_VERSION=$(echo $ALP_VIRT_LAST_ISO | cut -d'-' -f3)
+
+#Display detected last-version of virt
+echo "Last Alpine release for $ALP_ARCH version: $ALP_VIRT_VERSION  iso:$ALP_VIRT_LAST_ISO"
+echo "Starting download.."
+
+URL_DISTR="https://dl-cdn.alpinelinux.org/alpine/latest-stable/releases/$ALP_ARCH/$ALP_VIRT_LAST_ISO"
 
 # Download Alpine
 if [ ! -f $(basename $URL_DISTR) ]; then

--- a/x86/run.sh
+++ b/x86/run.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-DISK_NAME="alpine.x86.qcow2"
+ALP_ARCH=x86
+DISK_NAME="alpine.$ALP_ARCH.qcow2"
 PORT="2223"
 
 # Run qemu

--- a/x86_64/install.sh
+++ b/x86_64/install.sh
@@ -1,9 +1,18 @@
 #!/bin/bash
-
-URL_DISTR="https://dl-cdn.alpinelinux.org/alpine/v3.19/releases/x86_64/alpine-virt-3.19.0-x86_64.iso"
-
-DISK_NAME="alpine.x86_64.qcow2"
+ALP_ARCH=x86_64
+DISK_NAME="alpine.$ALP_ARCH.qcow2"
 DISK_SIZE="8G"
+
+#Get last release and iso file name
+ALP_VIRT_LAST_ISO=$(wget -qO- "https://dl-cdn.alpinelinux.org/alpine/latest-stable/releases/$ALP_ARCH/latest-releases.yaml" | grep "iso: alpine-virt" | cut -d':' -f2- | tr -d '[:space:]')
+
+ALP_VIRT_VERSION=$(echo $ALP_VIRT_LAST_ISO | cut -d'-' -f3)
+
+#Display detected last-version of virt
+echo "Last Alpine release for $ALP_ARCH version: $ALP_VIRT_VERSION  iso:$ALP_VIRT_LAST_ISO"
+echo "Starting download.."
+
+URL_DISTR="https://dl-cdn.alpinelinux.org/alpine/latest-stable/releases/$ALP_ARCH/$ALP_VIRT_LAST_ISO"
 
 # Download Alpine
 if [ ! -f $(basename $URL_DISTR) ]; then

--- a/x86_64/run.sh
+++ b/x86_64/run.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
+ALP_ARCH=x86_64
+DISK_NAME="alpine.$ALP_ARCH.qcow2"
 
-DISK_NAME="alpine.x86_64.qcow2"
 PORT="2224"
 
 # Run qemu


### PR DESCRIPTION
I have implemented a new feature that automatically detects the latest release of Alpine Virt before downloading. Additionally, fixed broken links for qemu-efi-arm and qemu-efi-aarch64. Hope to contribute.